### PR TITLE
update numpy from 0.17.0 to 0.19.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Pillow==3.0.0
-scipy==0.17.0
+scipy==0.19.0
 tqdm==3.8.0


### PR DESCRIPTION
It's been a while. Tests still pass and the README example works. Need to add CI...